### PR TITLE
refactor: type of Board.waste

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -103,7 +103,7 @@ pub fn describe_action(board: &Board, action: &Action) -> String {
 
     match action {
         Action::WasteToFoundation(foundation_index) => {
-            let from_card = format_card(board.waste.peek_top());
+            let from_card = format_card(board.waste.last());
             let to_card = format_card(board.foundations[*foundation_index].as_ref());
             format!(
                 "(Waste) {from_card} -> (Foundation{}) {to_card}",
@@ -111,7 +111,7 @@ pub fn describe_action(board: &Board, action: &Action) -> String {
             )
         }
         Action::WasteToTableau(tableau_index) => {
-            let from_card = format_card(board.waste.peek_top());
+            let from_card = format_card(board.waste.last());
             let to_card = format_card(board.tableaus[*tableau_index].peek_top());
             format!(
                 "(Waste) {from_card} -> (Tableau{}) {to_card}",
@@ -155,7 +155,7 @@ pub fn describe_action(board: &Board, action: &Action) -> String {
         Action::Draw => {
             let mut board = board.clone();
             board.draw();
-            let card = format_card(board.waste.peek_top());
+            let card = format_card(board.waste.last());
             format!("Draw {card}",)
         }
         Action::Redeal => "Redeal".to_string(),

--- a/src/autoplay/mod.rs
+++ b/src/autoplay/mod.rs
@@ -52,7 +52,7 @@ fn play_action(
         Action::WasteToFoundation(foundation_index) => {
             mouse_move(
                 enigo,
-                window.waste_point(board.waste.visible_count),
+                window.waste_point(),
                 window.foundation_point(*foundation_index),
             )?;
         }
@@ -60,7 +60,7 @@ fn play_action(
             let tableau = &board.tableaus[*tableau_index];
             mouse_move(
                 enigo,
-                window.waste_point(board.waste.visible_count),
+                window.waste_point(),
                 window.move_to_tableau_point(
                     *tableau_index,
                     tableau.cards.len(),

--- a/src/autoplay/window.rs
+++ b/src/autoplay/window.rs
@@ -52,11 +52,9 @@ impl Window {
         self.transform(STOCK_CENTER_X, STOCK_CLICK_Y)
     }
 
-    pub fn waste_point(&self, uncovered_count: usize) -> Point {
+    pub fn waste_point(&self) -> Point {
         self.transform(
-            STOCK_CENTER_X
-                + TABLEAU_OFFSET_X
-                + (uncovered_count.saturating_sub(1)) as i32 * WASTE_OFFSET_X,
+            STOCK_CENTER_X + TABLEAU_OFFSET_X + WASTE_OFFSET_X,
             STOCK_CLICK_Y,
         )
     }
@@ -228,8 +226,8 @@ mod tests {
         );
         assert_eq!(window.stock_point(), (191, 185), "Stock point mismatch");
         assert_eq!(
-            window.waste_point(3),
-            (531, 185),
+            window.waste_point(),
+            (494, 185),
             "Waste (3th) point mismatch"
         );
         assert_eq!(

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,6 +1,6 @@
 //! Reads the memory of the Solitaire process to extract the game state.
 
-use crate::board::{Board, Card, TOTAL_FOUNDATIONS, TOTAL_TABLEAUS, Tableau, WastePile};
+use crate::board::{Board, Card, TOTAL_FOUNDATIONS, TOTAL_TABLEAUS, Tableau};
 
 use anyhow::{Context, Result, anyhow, bail};
 use std::ffi::{OsStr, OsString};
@@ -90,8 +90,8 @@ impl Inspector {
         let (stock_cards, _) = self.read_pile(&pile_list.piles, STOCK_PILE_INDEX)?;
         board.stock = stock_cards.into_iter().collect();
 
-        let (waste_cards, visible_count) = self.read_pile(&pile_list.piles, WASTE_PILE_INDEX)?;
-        board.waste = WastePile::new(waste_cards, visible_count);
+        let (waste_cards, _) = self.read_pile(&pile_list.piles, WASTE_PILE_INDEX)?;
+        board.waste = waste_cards.into_iter().collect();
 
         Ok(board)
     }

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -732,7 +732,7 @@ impl Solver {
         {
             let pile = &mut self.initial_piles[PILE_WASTE];
             pile.reset();
-            for card in board.waste.cards.iter() {
+            for card in board.waste.iter() {
                 pile.push_card(card.into());
             }
         }
@@ -794,12 +794,8 @@ impl Solver {
         {
             let waste_pile = &self.piles[PILE_WASTE];
             for i in 0..waste_pile.size {
-                board
-                    .waste
-                    .cards
-                    .push(Card::new_with_id(waste_pile.get(i).id));
+                board.waste.push(Card::new_with_id(waste_pile.get(i).id));
             }
-            board.waste.visible_count = 1;
         }
 
         for i in 0..TOTAL_FOUNDATIONS {


### PR DESCRIPTION
From `WastePile` to `SmallVec<[Card; TALON_SIZE]>` since `visible_count` doesn't have much use and only complicates simple problems.

```
#[derive(Debug, Clone, Default)]
pub struct WastePile {
    pub cards: SmallVec<[Card; TALON_SIZE]>,
    pub visible_count: usize,
}
```